### PR TITLE
Created the requirements_tests.txt to carry extra dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
-install: "pip install -r requirements.txt"
+install:
+  - "pip install -r requirements.txt"
+  - "pip install -r requirements_tests.txt"
 script:
-  - nosetests firenado.test.core
+  - "nosetests firenado.test.core"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-nose==1.3.7
 pyyaml==3.11
 tornado==4.2.1
 six==1.10.0

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,0 +1,3 @@
+nose==1.3.7
+redis==2.10.3
+sqlalchemy==1.0.4


### PR DESCRIPTION
Firenado will only install with pyyaml, tornado and six. Extra
dependencies like redis, sqlalchemy and packages for testing
will be carried on the requirements_tests.txt.

Travis will install the requirements_tests.txt too.

Fix: #53