### PR TITLE
Removed python 3.2 from the test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
 install:


### PR DESCRIPTION
Tornado is not supporting this version anymore.

Python 2.6 is not being considered on the test.

Fixes: #118